### PR TITLE
Introduce tripleo_ceph_set_container_cli role

### DIFF
--- a/roles/tripleo_cluster_set_container_cli/.travis.yml
+++ b/roles/tripleo_cluster_set_container_cli/.travis.yml
@@ -1,0 +1,29 @@
+---
+language: python
+python: "2.7"
+
+# Use the new container infrastructure
+sudo: false
+
+# Install ansible
+addons:
+  apt:
+    packages:
+    - python-pip
+
+install:
+  # Install ansible
+  - pip install ansible
+
+  # Check ansible version
+  - ansible --version
+
+  # Create ansible.cfg with correct roles_path
+  - printf '[defaults]\nroles_path=../' >ansible.cfg
+
+script:
+  # Basic role syntax check
+  - ansible-playbook tests/test.yml -i tests/inventory --syntax-check
+
+notifications:
+  webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/roles/tripleo_cluster_set_container_cli/README.md
+++ b/roles/tripleo_cluster_set_container_cli/README.md
@@ -1,0 +1,38 @@
+Role Name
+=========
+
+A brief description of the role goes here.
+
+Requirements
+------------
+
+Any pre-requisites that may not be covered by Ansible itself or the role should be mentioned here. For instance, if the role uses the EC2 module, it may be a good idea to mention in this section that the boto package is required.
+
+Role Variables
+--------------
+
+A description of the settable variables for this role should go here, including any variables that are in defaults/main.yml, vars/main.yml, and any variables that can/should be set via parameters to the role. Any variables that are read from other roles and/or the global scope (ie. hostvars, group vars, etc.) should be mentioned here as well.
+
+Dependencies
+------------
+
+A list of other roles hosted on Galaxy should go here, plus any details in regards to parameters that may need to be set for other roles, or variables that are used from other roles.
+
+Example Playbook
+----------------
+
+Including an example of how to use your role (for instance, with variables passed in as parameters) is always nice for users too:
+
+    - hosts: servers
+      roles:
+         - { role: username.rolename, x: 42 }
+
+License
+-------
+
+BSD
+
+Author Information
+------------------
+
+An optional section for the role authors to include contact information, or a website (HTML is not allowed).

--- a/roles/tripleo_cluster_set_container_cli/defaults/main.yml
+++ b/roles/tripleo_cluster_set_container_cli/defaults/main.yml
@@ -1,0 +1,10 @@
+---
+# defaults file for tripleo_ceph_set_container_cli
+ceph_dot_conf: "{{ ceph_config_home}}/ceph.conf"
+ceph_keyring: "{{ ceph_config_home }}/ceph.client.admin.keyring"
+ceph_container_ns: "docker.io/ceph"
+ceph_container_image: "ceph"
+ceph_container_tag: "v15"
+container_cli: "podman"
+container_options: "--net=host --ipc=host"
+debug_orch: false

--- a/roles/tripleo_cluster_set_container_cli/handlers/main.yml
+++ b/roles/tripleo_cluster_set_container_cli/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for tripleo_ceph_set_container_cli

--- a/roles/tripleo_cluster_set_container_cli/meta/main.yml
+++ b/roles/tripleo_cluster_set_container_cli/meta/main.yml
@@ -1,0 +1,53 @@
+galaxy_info:
+  author: your name
+  description: your role description
+  company: your company (optional)
+
+  # If the issue tracker for your role is not on github, uncomment the
+  # next line and provide a value
+  # issue_tracker_url: http://example.com/issue/tracker
+
+  # Choose a valid license ID from https://spdx.org - some suggested licenses:
+  # - BSD-3-Clause (default)
+  # - MIT
+  # - GPL-2.0-or-later
+  # - GPL-3.0-only
+  # - Apache-2.0
+  # - CC-BY-4.0
+  license: license (GPL-2.0-or-later, MIT, etc)
+
+  min_ansible_version: 2.9
+
+  # If this a Container Enabled role, provide the minimum Ansible Container version.
+  # min_ansible_container_version:
+
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  # platforms:
+  # - name: Fedora
+  #   versions:
+  #   - all
+  #   - 25
+  # - name: SomePlatform
+  #   versions:
+  #   - all
+  #   - 1.0
+  #   - 7
+  #   - 99.99
+
+  galaxy_tags: []
+    # List tags for your role here, one per line. A tag is a keyword that describes
+    # and categorizes the role. Users find roles by searching for tags. Be sure to
+    # remove the '[]' above, if you add tags to this list.
+    #
+    # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
+    #       Maximum 20 tags per role.
+
+dependencies: []
+  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
+  # if you add dependencies to this list.
+  

--- a/roles/tripleo_cluster_set_container_cli/tasks/main.yml
+++ b/roles/tripleo_cluster_set_container_cli/tasks/main.yml
@@ -1,0 +1,2 @@
+---
+# tasks file for tripleo_ceph_set_container_cli

--- a/roles/tripleo_cluster_set_container_cli/tasks/set_container_cli.yaml
+++ b/roles/tripleo_cluster_set_container_cli/tasks/set_container_cli.yaml
@@ -1,0 +1,22 @@
+- name: Get ceph fsid
+  command: "awk '/fsid/ {print $3}' /etc/ceph/ceph.conf"
+  register: fsid
+  run_once: true
+  changed_when: false
+
+- name: Set fsid fact
+  set_fact:
+    fsid: "{{ fsid.stdout }}"
+
+- name: Set client fact
+  set_fact:
+    ceph_cli: "{{ container_cli }} run --rm -it {{ container_options }} -v {{ ceph_config_home}}:/etc/ceph:z
+               {{ ceph_container_ns }}/{{ ceph_container_image }}:{{ ceph_container_tag }} ceph --fsid {{ fsid }}
+               -c {{ ceph_dot_conf }} -k {{ ceph_keyring }}"
+  run_once: true
+  become: true
+
+- name: Debug task - Check if ceph_cli is working properly
+  command: "{{ ceph_cli }} orch status"
+  become: true
+  when: debug_orch

--- a/roles/tripleo_cluster_set_container_cli/tests/inventory
+++ b/roles/tripleo_cluster_set_container_cli/tests/inventory
@@ -1,0 +1,2 @@
+localhost
+

--- a/roles/tripleo_cluster_set_container_cli/tests/test.yml
+++ b/roles/tripleo_cluster_set_container_cli/tests/test.yml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - tripleo_ceph_set_container_cli

--- a/roles/tripleo_cluster_set_container_cli/vars/main.yml
+++ b/roles/tripleo_cluster_set_container_cli/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for tripleo_ceph_set_container_cli

--- a/site.yaml
+++ b/site.yaml
@@ -2,7 +2,7 @@
 - hosts: allovercloud
   vars:
     cephadm_bin_home: "/usr/sbin"
-    cephadm_pkg: "https://download.ceph.com/rpm-octopus/el8/x86_64/cephadm-15.2.2-0.el8.x86_64.rpm"
+    cephadm_pkg: "https://download.ceph.com/rpm-octopus/el8/x86_64/cephadm-15.2.3-0.el8.x86_64.rpm"
     ceph_public_network: "172.16.11.0/24"
   tasks:
     - name: Bootstrap the first minimal ceph cluster via cephadm
@@ -34,20 +34,12 @@
     ceph_keyring: "{{ ceph_config_home }}/ceph.client.admin.keyring"
     apply_spec: false
   tasks:
-    - name: Get ceph fsid
-      command: "awk '/fsid/ {print $3}' /etc/ceph/ceph.conf"
-      register: fsid
-      run_once: true
-      changed_when: false
-
-    - name: Set fsid fact
-      set_fact:
-        fsid: "{{ fsid.stdout }}"
-
     - name: Set client fact
-      set_fact:
-        ceph_cli: "{{ cephadm_bin_home }}/cephadm shell --fsid {{ fsid }} -c {{ ceph_dot_conf }} -k {{ ceph_keyring }} -- ceph"
-      run_once: true
+      include_role:
+        name: tripleo_ceph_set_container_cli
+        tasks_from: set_container_cli
+      tags:
+        - ceph_client
 
     - name: Use ceph orchestrator to scale ceph cluster
       when:


### PR DESCRIPTION
This role sets a new `ceph_cli` fact getting rid
of the cephadm binary. In fact, it's now possible
to run a octopus container which acts as a ceph
client.
By using a role we can customize  many container
options (e.g., changing fsid or ceph.conf file it can
interact with different ceph clusters).

The site.yaml is updated with this new role and the
cephadm rpm package is fixed as well.

Signed-off-by: Francesco Pantano <fpantano@redhat.com>