### PR TITLE
Rename tripleo_ceph_ to tripleo_cluster_

### DIFF
--- a/site.yaml
+++ b/site.yaml
@@ -36,7 +36,7 @@
   tasks:
     - name: Set client fact
       include_role:
-        name: tripleo_ceph_set_container_cli
+        name: tripleo_cluster_set_container_cli
         tasks_from: set_container_cli
       tags:
         - ceph_client
@@ -60,7 +60,7 @@
             tasks_from: add
           vars:
             ceph_client: "{{ ceph_cli }}"
-            all_available: false
+            all_available: true
             devices: []
           tags:
             - osds


### PR DESCRIPTION

Because the role is named with _cluster_ and not with _ceph_ we need to call a different name.

Also, set all_available=true so that the deployment doesn't fail when it's false from this line [1]. I will propose a fix for that soon.

[1] https://github.com/fmount/tripleo-ceph/blob/master/roles/tripleo_cluster_osds/tasks/add.yml#L5