### PR TITLE
Introduce tripleo_cluster_mon_config role

### DIFF
--- a/roles/tripleo_cluster_bootstrap/tasks/bootstrap.yaml
+++ b/roles/tripleo_cluster_bootstrap/tasks/bootstrap.yaml
@@ -59,10 +59,3 @@
     ceph_cli: "{{ cephadm_bin_home }}/cephadm shell --fsid {{ fsid.stdout }} -c {{ ceph_dot_conf }} -k {{ ceph_keyring }} -- ceph"
   run_once: true
   delegate_to: "{{ groups.get('mons', {})[0] }}"
-
-- name: Set ceph monitors public network (we're going to use this network to deploy additional monitors)
-  command: "{{ ceph_cli }} config set mon public_network {{ ceph_public_network }}"
-  register: result
-  become: true
-  run_once: true
-  delegate_to: "{{ groups.get('mons', {})[0] }}"

--- a/roles/tripleo_cluster_mon_config/.travis.yml
+++ b/roles/tripleo_cluster_mon_config/.travis.yml
@@ -1,0 +1,29 @@
+---
+language: python
+python: "2.7"
+
+# Use the new container infrastructure
+sudo: false
+
+# Install ansible
+addons:
+  apt:
+    packages:
+    - python-pip
+
+install:
+  # Install ansible
+  - pip install ansible
+
+  # Check ansible version
+  - ansible --version
+
+  # Create ansible.cfg with correct roles_path
+  - printf '[defaults]\nroles_path=../' >ansible.cfg
+
+script:
+  # Basic role syntax check
+  - ansible-playbook tests/test.yml -i tests/inventory --syntax-check
+
+notifications:
+  webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/roles/tripleo_cluster_mon_config/README.md
+++ b/roles/tripleo_cluster_mon_config/README.md
@@ -1,0 +1,38 @@
+Role Name
+=========
+
+A brief description of the role goes here.
+
+Requirements
+------------
+
+Any pre-requisites that may not be covered by Ansible itself or the role should be mentioned here. For instance, if the role uses the EC2 module, it may be a good idea to mention in this section that the boto package is required.
+
+Role Variables
+--------------
+
+A description of the settable variables for this role should go here, including any variables that are in defaults/main.yml, vars/main.yml, and any variables that can/should be set via parameters to the role. Any variables that are read from other roles and/or the global scope (ie. hostvars, group vars, etc.) should be mentioned here as well.
+
+Dependencies
+------------
+
+A list of other roles hosted on Galaxy should go here, plus any details in regards to parameters that may need to be set for other roles, or variables that are used from other roles.
+
+Example Playbook
+----------------
+
+Including an example of how to use your role (for instance, with variables passed in as parameters) is always nice for users too:
+
+    - hosts: servers
+      roles:
+         - { role: username.rolename, x: 42 }
+
+License
+-------
+
+BSD
+
+Author Information
+------------------
+
+An optional section for the role authors to include contact information, or a website (HTML is not allowed).

--- a/roles/tripleo_cluster_mon_config/defaults/main.yml
+++ b/roles/tripleo_cluster_mon_config/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+# defaults file for tripleo_cluster_mon_config

--- a/roles/tripleo_cluster_mon_config/handlers/main.yml
+++ b/roles/tripleo_cluster_mon_config/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for tripleo_cluster_mon_config

--- a/roles/tripleo_cluster_mon_config/meta/main.yml
+++ b/roles/tripleo_cluster_mon_config/meta/main.yml
@@ -1,0 +1,53 @@
+galaxy_info:
+  author: your name
+  description: your role description
+  company: your company (optional)
+
+  # If the issue tracker for your role is not on github, uncomment the
+  # next line and provide a value
+  # issue_tracker_url: http://example.com/issue/tracker
+
+  # Choose a valid license ID from https://spdx.org - some suggested licenses:
+  # - BSD-3-Clause (default)
+  # - MIT
+  # - GPL-2.0-or-later
+  # - GPL-3.0-only
+  # - Apache-2.0
+  # - CC-BY-4.0
+  license: license (GPL-2.0-or-later, MIT, etc)
+
+  min_ansible_version: 2.9
+
+  # If this a Container Enabled role, provide the minimum Ansible Container version.
+  # min_ansible_container_version:
+
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  # platforms:
+  # - name: Fedora
+  #   versions:
+  #   - all
+  #   - 25
+  # - name: SomePlatform
+  #   versions:
+  #   - all
+  #   - 1.0
+  #   - 7
+  #   - 99.99
+
+  galaxy_tags: []
+    # List tags for your role here, one per line. A tag is a keyword that describes
+    # and categorizes the role. Users find roles by searching for tags. Be sure to
+    # remove the '[]' above, if you add tags to this list.
+    #
+    # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
+    #       Maximum 20 tags per role.
+
+dependencies: []
+  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
+  # if you add dependencies to this list.
+  

--- a/roles/tripleo_cluster_mon_config/tasks/main.yml
+++ b/roles/tripleo_cluster_mon_config/tasks/main.yml
@@ -1,0 +1,2 @@
+---
+# tasks file for tripleo_cluster_mon_config

--- a/roles/tripleo_cluster_mon_config/tasks/set_monitor_public_network.yaml
+++ b/roles/tripleo_cluster_mon_config/tasks/set_monitor_public_network.yaml
@@ -1,0 +1,6 @@
+---
+- name: Set ceph monitors public network (we're going to use this network to deploy additional monitors)
+  command: "{{ ceph_cli }} config set mon public_network {{ ceph_public_network }}"
+  register: result
+  become: true
+  run_once: true

--- a/roles/tripleo_cluster_mon_config/tests/inventory
+++ b/roles/tripleo_cluster_mon_config/tests/inventory
@@ -1,0 +1,2 @@
+localhost
+

--- a/roles/tripleo_cluster_mon_config/tests/test.yml
+++ b/roles/tripleo_cluster_mon_config/tests/test.yml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - tripleo_cluster_mon_config

--- a/roles/tripleo_cluster_mon_config/vars/main.yml
+++ b/roles/tripleo_cluster_mon_config/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for tripleo_cluster_mon_config

--- a/site.yaml
+++ b/site.yaml
@@ -3,7 +3,6 @@
   vars:
     cephadm_bin_home: "/usr/sbin"
     cephadm_pkg: "https://download.ceph.com/rpm-octopus/el8/x86_64/cephadm-15.2.3-0.el8.x86_64.rpm"
-    ceph_public_network: "172.16.11.0/24"
   tasks:
     - name: Bootstrap the first minimal ceph cluster via cephadm
       include_role:
@@ -32,6 +31,7 @@
     ceph_config_home: "/etc/ceph"
     ceph_dot_conf: "{{ ceph_config_home}}/ceph.conf"
     ceph_keyring: "{{ ceph_config_home }}/ceph.client.admin.keyring"
+    ceph_public_network: "172.16.11.0/24"
     apply_spec: false
   tasks:
     - name: Set client fact
@@ -40,6 +40,15 @@
         tasks_from: set_container_cli
       tags:
         - ceph_client
+
+    - name: Apply MONs options
+      include_role:
+        name: tripleo_cluster_mon_config
+        tasks_from: set_monitor_public_network
+      vars:
+        ceph_client: "{{ ceph_cli }}"
+      tags:
+        - mon_config
 
     - name: Use ceph orchestrator to scale ceph cluster
       when:


### PR DESCRIPTION
The purpose of this role is to run ceph commands
to add options and configurations to the monitors.
Since this is a post bootstrap action, it's removed
from that role and executed after a client has been
created.

Signed-off-by: Francesco Pantano <fpantano@redhat.com>