### PR TITLE
Improve Ceph services spec definition

### DIFF
--- a/roles/tripleo_cluster_spec_render/defaults/main.yml
+++ b/roles/tripleo_cluster_spec_render/defaults/main.yml
@@ -1,14 +1,16 @@
 ---
 # defaults file for tripleo_cluster_deploy
 tripleo_cephadm_services:
-  - mon
-  - mgr
-  - osd
+  - {'service': 'mon', 'regex': '*controller*', 'label': 'mon'}
+  - {'service': 'mgr', 'regex': '*controller*', 'label': 'mgr'}
+  - {'service': 'osd', 'regex': '*ceph*', 'label': 'osd'}
+
 # leaving an empty data_devices result in --all-available-devices
 # TODO: Add filter options to data_devices
 data_devices: {}
 use_labels: false
 use_pattern: true
+encrypted: false
 dest_path: /etc/ceph
 ceph_template_list:
   - spec.yaml

--- a/roles/tripleo_cluster_spec_render/tasks/build_spec.yaml
+++ b/roles/tripleo_cluster_spec_render/tasks/build_spec.yaml
@@ -1,11 +1,4 @@
 ---
-- name: Print the ceph cluster status
-  command: "{{ ceph_client }} orch status"
-  become: true
-  register: c_status
-  run_once: true
-  delegate_to: "{{ groups.get('mons', {})[0] }}"
-
 - name: Render the spec
   template:
     src: templates/{{ item }}.j2

--- a/roles/tripleo_cluster_spec_render/templates/host.yaml.j2
+++ b/roles/tripleo_cluster_spec_render/templates/host.yaml.j2
@@ -2,13 +2,14 @@
 {% if host != 'undercloud' %}
 ---
 service_type: host
-addr: {{ host }}
-hostname: {{ hostvars[host]['inventory_hostname'] }}
-labels:
+spec:
+  addr: {{ host }}
+  hostname: {{ hostvars[host]['inventory_hostname'] }}
+  labels:
 {% for group in labels %}
 {% if host in groups[group] %}
 {% for label in labels[group] %}
-  - {{ label }}
+    - {{ label }}
 {% endfor %}
 {% endif %}
 {% endfor %}

--- a/roles/tripleo_cluster_spec_render/templates/spec.yaml.j2
+++ b/roles/tripleo_cluster_spec_render/templates/spec.yaml.j2
@@ -1,20 +1,21 @@
-{% for service in tripleo_cephadm_services %}
+{% for item in tripleo_cephadm_services %}
 ---
-service_type: {{ service }}
-service_id: {{ service }}
+service_type: {{ item['service'] }}
+service_id: {{ item['service'] }}
 placement:
-{% if use_pattern %}
-  host_pattern: "{{ service }}*"
+{% if use_pattern or 'osd' in item['service'] %}
+  host_pattern: "{{ item['regex'] }}*"
 {% elif use_labels %}
-  label: {{ service }}
+  label: {{ item['label'] }}
 {% else %}
   hosts:
-{% for host in (groups['ceph_' + service]) %}
+{% for host in (groups['ceph_' + item['service']]|default(groups['ceph_mon'])) %}
     - {{ host }}
 {% endfor %}
 {% endif %}
-{% if 'osd' in service and data_devices | length == 0%}
+{% if 'osd' in item['service'] and data_devices | length == 0%}
 data_devices:
   all: true
+encrypted: {{ 'true' if encrypted else 'false' }}
 {% endif %}
 {% endfor %}

--- a/site.yaml
+++ b/site.yaml
@@ -121,6 +121,8 @@
           vars:
             ceph_client: "{{ ceph_cli }}"
             dest_path: "/etc/ceph"
+            use_labels: false
+            use_pattern: false
           tags:
             - ceph_spec
             - day1


### PR DESCRIPTION
The purpose of this commit is to improve the way the spec
and the hostmap are built.
Now there are three models (according to [1]):

1. by pattern
2. by label
3. by hosts

Sounds like OSDs support by pattern only, hence the spec
is aligned with this model.
Further, for each service a structure is defined and can
be extendend in future.
Useless print (e.g., ceph orch status) are removed from
this role.
[1] https://github.com/ceph/ceph/blob/master/doc/mgr/orchestrator.rst

Signed-off-by: Francesco Pantano <fpantano@redhat.com>