### PR TITLE
Fix add.yml task removing force option

### DIFF
--- a/roles/tripleo_cluster_osds/tasks/add.yml
+++ b/roles/tripleo_cluster_osds/tasks/add.yml
@@ -7,13 +7,9 @@
   when: "{{ devices | length == 0 }}"
 
 - name: Apply OSDs using the device list
-  shell: "{{ ceph_cli }} orch daemon add osd {{ item }}:{{ devices|join(',') }} --force"
-  register: orch_dev_zap
+  shell: "{{ ceph_cli }} orch daemon add osd {{ item }}:{{ devices|join(',') }}"
+  register: orch_apply_osd
   become: true
   ignore_errors: true
   with_items:
     - "{{ groups.get('osds', {}) }}"
-
-- name: show output of 'ceph orch apply osd'
-  debug:
-    msg: "{{ orch_apply_osd.stdout_lines }}"


### PR DESCRIPTION
This change just fixes the "add osd" cmd
and the registered variable that should be
used to show the result.

Signed-off-by: Francesco Pantano <fpantano@redhat.com>