### PR TITLE
Fix permissions when looking if /etc/ceph exists

### DIFF
--- a/roles/ceph_client/tasks/sync.yml
+++ b/roles/ceph_client/tasks/sync.yml
@@ -8,10 +8,11 @@
   delegate_to: "{{ groups.get('mons', {})[0] }}"
 
 - name: Ensure /etc/ceph exists on all nodes of cluster
+  become: true
   file:
     path: "{{ path }}"
     state: "directory"
-  
+
 - name: push files to other nodes of cluster
   become: true
   synchronize:


### PR DESCRIPTION
This commit just adds the become: true option to
the task that is looking for /etc/ceph on Ceph
nodes.
Currently this fails reporting a permission denied
error.

Signed-off-by: Francesco Pantano <fpantano@redhat.com>