### PR TITLE
Extend spec definition improving the related data structures

### DIFF
--- a/roles/tripleo_cluster_spec_apply/defaults/main.yml
+++ b/roles/tripleo_cluster_spec_apply/defaults/main.yml
@@ -2,6 +2,6 @@
 # defaults file for tripleo_cluster_spec_apply
 
 ## We can apply the config using host mode or spec mode
-config_mode: "host"
-#config_mode: "spec"
-spec_path: /home/heat-admin
+#config_mode: "host"
+config_mode: "spec"
+spec_path: /etc/ceph

--- a/roles/tripleo_cluster_spec_render/defaults/main.yml
+++ b/roles/tripleo_cluster_spec_render/defaults/main.yml
@@ -1,16 +1,14 @@
 ---
 # defaults file for tripleo_cluster_deploy
 tripleo_cephadm_services:
-  - {'service': 'mon', 'regex': '*controller*', 'label': 'mon'}
-  - {'service': 'mgr', 'regex': '*controller*', 'label': 'mgr'}
-  - {'service': 'osd', 'regex': '*ceph*', 'label': 'osd'}
+  - {'service_type': 'mon', 'service_id': 'mon', 'regex': '*controller*', 'label': 'mon'}
+  - {'service_type': 'mgr', 'service_id': 'mgr', 'regex': '*controller*', 'label': 'mgr'}
+  - {'service_type': 'osd', 'service_id': 'osd', 'regex': '*ceph*', 'label': 'osd'}
+  - {'service_type': 'nfs', 'service_id': 'nfs', 'regex': '*controller*', 'label': 'nfs',
+    'spec': {'pool': 'mynfspool', 'namespace': 'myns'}}
 
-# leaving an empty data_devices result in --all-available-devices
-# TODO: Add filter options to data_devices
-data_devices: {}
 use_labels: false
 use_pattern: true
-encrypted: false
 dest_path: /etc/ceph
 ceph_template_list:
   - spec.yaml
@@ -30,3 +28,27 @@ labels:
     - osd
     - node-exporter
 
+# Devices filter section
+# leaving an empty data_devices results in --all-available-devices
+data_devices: {}
+db_devices: {}
+wal_devices: {}
+encrypted: false
+
+# Filters example
+
+#data_devices:
+#  filters:
+#    rotational: 1
+#    size: "2TB"
+#db_devices:
+#  filters:
+#    model: "ModelB"
+#    size: "10G"
+#    rotational: 0
+#    limit: 2
+#wal_devices:
+#  filters:
+#    model: "ModelC"
+#    size: "10G"
+#    rotational: 0

--- a/roles/tripleo_cluster_spec_render/tasks/build_spec.yaml
+++ b/roles/tripleo_cluster_spec_render/tasks/build_spec.yaml
@@ -6,4 +6,3 @@
   loop: "{{ ceph_template_list }}"
   become: true
   run_once: true
-  delegate_to: "{{ groups.get('mons', {})[0] }}"

--- a/roles/tripleo_cluster_spec_render/templates/spec.yaml.j2
+++ b/roles/tripleo_cluster_spec_render/templates/spec.yaml.j2
@@ -1,21 +1,49 @@
+{# MACRO AREA #}
+{% macro render_map(root, fltr) -%}
+{% for key, value in root.get(fltr, {}).items() %}
+  {{ key}}: {{ value }}
+{% endfor %}
+{% endmacro %}
 {% for item in tripleo_cephadm_services %}
 ---
-service_type: {{ item['service'] }}
-service_id: {{ item['service'] }}
+service_type: {{ item['service_type'] }}
+service_id: {{ item['service_id'] }}
 placement:
-{% if use_pattern or 'osd' in item['service'] %}
-  host_pattern: "{{ item['regex'] }}*"
+count: {{ item['count'] | default((groups['ceph_' + item['service_type']] | default(groups['ceph_mon'])) | length) }}
+{% if use_pattern or 'osd' in item['service_type'] %}
+  host_pattern: "{{ item['regex'] }}"
 {% elif use_labels %}
   label: {{ item['label'] }}
 {% else %}
   hosts:
-{% for host in (groups['ceph_' + item['service']]|default(groups['ceph_mon'])) %}
+{% for host in (groups['ceph_' + item['service_type']] | default(groups['ceph_mon'])) %}
     - {{ host }}
 {% endfor %}
 {% endif %}
-{% if 'osd' in item['service'] and data_devices | length == 0%}
+{# OSD SECTION #}
+{% if 'osd' in item['service_type'] %}
 data_devices:
+{% if data_devices | length == 0%}
   all: true
+{% else %}
+{# RENDER #}
+{{render_map(data_devices, 'filters')}}
+{%- endif %}
+{% if db_devices | length != 0 -%}
+db_devices:
+{# RENDER #}
+{{render_map(db_devices, 'filters')}}
+{%- endif %}
+{% if wal_devices | length != 0 -%}
+wal_devices:
+{# RENDER #}
+{{render_map(wal_devices, 'filters')}}
+{%- endif %}
 encrypted: {{ 'true' if encrypted else 'false' }}
 {% endif %}
+{# RENDER SPEC FOR GENERIC ITEMS #}
+{% if item.get('spec', {}) | length > 0 %}
+spec:
+{{ render_map(item, 'spec') }}
+{%- endif %}
 {% endfor %}

--- a/site.yaml
+++ b/site.yaml
@@ -113,6 +113,17 @@
       when:
         - apply_spec
       block:
+        # This task will be no longer required after PR#34879
+        # will be available
+        - name: Add all the Ceph cluster hosts via orchestrator
+          include_role:
+            name: tripleo_cluster_add_nodes
+            tasks_from: nodes
+          vars:
+            ceph_client: "{{ ceph_cli }}"
+          tags:
+            - nodes
+
         - name: Build the Ceph Cluster spec and apply it via orchestrator
           include_role:
             name: tripleo_cluster_spec_render
@@ -122,6 +133,14 @@
             dest_path: "/etc/ceph"
             use_labels: false
             use_pattern: false
+            tripleo_cephadm_services:
+              - {'service_type': 'mon', 'service_id': 'mon', 'regex': '*controller*', 'label': 'mon'}
+              - {'service_type': 'mgr', 'service_id': 'mgr', 'regex': '*controller*', 'label': 'mgr'}
+              - {'service_type': 'osd', 'service_id': 'osd', 'regex': '*ceph*', 'label': 'osd'}
+              - {'service_type': 'rgw', 'service_id': 'realm.zone', 'regex': '*controller*', 'label': 'rgw'}
+              - {'service_type': 'mds', 'service_id': 'mds', 'regex': '*controller*', 'label': 'mds'}
+              - {'service_type': 'nfs', 'service_id': 'nfs', 'regex': '*controller*', 'label': 'nfs',
+                'spec': {'pool': 'mynfspool', 'namespace': 'myns'}}
           tags:
             - ceph_spec
             - day1
@@ -132,7 +151,7 @@
             tasks_from: apply_spec
           vars:
             ceph_client: "{{ ceph_cli }}"
-            config_mode: "host"
+            config_mode: "spec"
             spec_path: "/etc/ceph"
           tags:
             - ceph_spec_apply


### PR DESCRIPTION
The purpose of this commit is to improve the way the spec is built for
multiple Ceph services.
In particular, 'service_type' and 'service_id' are added to cover Ceph
services != (mon, mgr, osd).
The data structure 'tripleo_cephadm_services' is now extended and the
spec template is able to process a new 'spec' structure associated to
a given service.
By doing this an arbitrary number of options can be added to a specific
service and passed as input.
The count option is now available and this value can be retrieved from
the structure (the operator can define the count number during the
deployment phase).
If no count is specified, the value is set to the number of hosts in
the related group.
For each osd data structure ({data,db,wal}_devices) there's a filter
map associated and can be rendered via the proper function.
The defined macro is also generic, and it's reused to render a generic
'section' (e.g., spec) which can be associated to a given Ceph service.

Signed-off-by: Francesco Pantano <fpantano@redhat.com>